### PR TITLE
Allow batching in FBX batch scripts

### DIFF
--- a/batch/fbx_to_nif.bat
+++ b/batch/fbx_to_nif.bat
@@ -1,2 +1,11 @@
 @echo off
-"%~dp0ck-cmd.exe" importfbx "%~1" -e .
+
+setlocal enabledelayedexpansion
+
+set argCount=0
+for %%x in (%*) do (
+   set /A argCount+=1
+   set "argVec[!argCount!]=%%~x"
+)
+
+for /L %%i in (1,1,%argCount%) do "%~dp0ck-cmd.exe" importfbx "!argVec[%%i]!" -e .

--- a/batch/nif_to_fbx.bat
+++ b/batch/nif_to_fbx.bat
@@ -1,2 +1,11 @@
 @echo off
-"%~dp0ck-cmd.exe" exportfbx "%~1" -e .
+
+setlocal enabledelayedexpansion
+
+set argCount=0
+for %%x in (%*) do (
+   set /A argCount+=1
+   set "argVec[!argCount!]=%%~x"
+)
+
+for /L %%i in (1,1,%argCount%) do "%~dp0ck-cmd.exe" exportfbx "!argVec[%%i]!" -e .


### PR DESCRIPTION
This sets the nif_to_fbx.bat and fbx_to_nif.bat batch scripts to accept multiple input files. For each input argument it performs the same command that it previously ran for the first argument. 
In windows explorer, if you select multiple files and drag them onto the .bat, it will now process them all instead of just one of them.